### PR TITLE
Fixed missing initialization of brandwidth toxic

### DIFF
--- a/Toxiproxy.Net/Client.cs
+++ b/Toxiproxy.Net/Client.cs
@@ -291,6 +291,10 @@ namespace Toxiproxy.Net
             collection.SlicerToxic.Client = this;
             collection.SlicerToxic.Direction = direction;
             collection.SlicerToxic.ParentProxy = proxyName;
+
+            collection.BandwidthToxic.Client = this;
+            collection.BandwidthToxic.Direction = direction;
+            collection.BandwidthToxic.ParentProxy = proxyName;
         }
     }
 }


### PR DESCRIPTION
I think the last refactoring introduced in 9a6b55d729d43e45e3c645c800648a7ea174624d missed the initialization of bandwidth toxic members
