### PR TITLE
remove coveralls upload

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,10 +5,6 @@ build:
   project: Toxiproxy.Net.sln
   verbosity: minimal
 
-environment:
-  COVERALLS_REPO_TOKEN:  
-    secure: 26bH2HPtzUIMzItgYkadz+zq96203FZn+70q1OHN0vX9tRQtzrpdHCmG0Hm8huLi
-
 after_build:
   - .nuget\nuget.exe pack Toxiproxy.Net.nuspec
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,6 @@ after_build:
 
 after_test: 
   - packages\OpenCover.4.5.3723\OpenCover.Console.exe -register:user -filter:"+[Toxiproxy*]* -[Toxiproxy.Net.Tests]*" -target:"packages\xunit.runner.console.2.0.0\tools\xunit.console.x86.exe" -targetargs:"Toxiproxy.Net.Tests\bin\debug\Toxiproxy.Net.Tests.dll -appveyor -noshadow" -output:coverage.xml
-  - packages\coveralls.io.1.3.2\tools\coveralls.net.exe --opencover -f -r %COVERALLS_REPO_TOKEN% coverage.xml
 
 artifacts:
   - path: '*.nupkg'


### PR DESCRIPTION
Uploading to coveralls seems to suffer from a failure probalby due to bit rot.
I don't have a windows machine to debug - so removing the feature in the meantime.