### PR TITLE
Fixing seralization to not include non set values

### DIFF
--- a/Toxiproxy.Net.Tests/ClientTests.cs
+++ b/Toxiproxy.Net.Tests/ClientTests.cs
@@ -167,5 +167,59 @@ namespace Toxiproxy.Net.Tests
                 client.FindProxy(ProxyOne.Name);
             });
         }
-    }
+
+		[Fact]
+		public void AddToxic_NullFields() {
+			// Create a proxy and add the proxy to the client
+			var client = _connection.Client();
+			client.Add( ProxyOne );
+
+			// Retrieve the proxy
+			var proxy = client.FindProxy( "one" );
+			var latencyToxic = new LatencyToxic();
+			latencyToxic.Attributes.Latency = 1000;
+
+			proxy.Add( latencyToxic );
+			proxy.Update();
+
+			var toxics = proxy.GetAllToxics();
+			Assert.Equal( 1, toxics.Count() );
+			var toxic = toxics.First();
+
+			Assert.Equal( 1, toxic.Toxicity );
+			Assert.Equal( ToxicDirection.DownStream, toxic.Stream );
+
+			//default pattern is <type>_<stream>
+			Assert.Equal( "latency_downstream", toxic.Name );
+		}
+
+		[Fact]
+		public void AddToxic_NonNullFields() {
+			// Create a proxy and add the proxy to the client
+			var client = _connection.Client();
+			client.Add( ProxyOne );
+
+			// Retrieve the proxy
+			var proxy = client.FindProxy( "one" );
+
+			var latencyToxic = new LatencyToxic();
+			latencyToxic.Attributes.Latency = 1000;
+			latencyToxic.Stream = ToxicDirection.UpStream;
+			latencyToxic.Name = "testName";
+			latencyToxic.Toxicity = 0.5;
+
+			proxy.Add( latencyToxic );
+			proxy.Update();
+
+			var toxics = proxy.GetAllToxics();
+			Assert.Equal( 1, toxics.Count() );
+			var toxic = toxics.First();
+
+			Assert.Equal( 0.5, toxic.Toxicity );
+			Assert.Equal( ToxicDirection.UpStream, toxic.Stream );
+
+			//default pattern is <type>_<stream>
+			Assert.Equal( "testName", toxic.Name );
+		}
+	}
 }

--- a/Toxiproxy.Net/Client.cs
+++ b/Toxiproxy.Net/Client.cs
@@ -238,7 +238,12 @@ namespace Toxiproxy.Net
             using (var client = _clientFactory.Create())
             {
                 var url = string.Format("proxies/{0}/toxics", proxy.Name);
-                var objectSerialized = JsonConvert.SerializeObject(toxic);
+				var objectSerialized = JsonConvert.SerializeObject( 
+						toxic, 
+						new JsonSerializerSettings {
+							NullValueHandling = NullValueHandling.Ignore
+						} 
+					);
                 var response = client.PostAsync(url, new StringContent(objectSerialized, Encoding.UTF8, "application/json")).Result;
 
                 CheckIsSuccessStatusCode(response);

--- a/Toxiproxy.Net/Toxics/ToxicBase.cs
+++ b/Toxiproxy.Net/Toxics/ToxicBase.cs
@@ -6,8 +6,8 @@
     public abstract class ToxicBase
     {
         public string Name { get; set; }
-        public ToxicDirection Stream { get; set; }
-        public double Toxicity { get; set; }
+        public ToxicDirection? Stream { get; set; }
+        public double? Toxicity { get; set; }
 
         public abstract string Type { get; }
 


### PR DESCRIPTION
Currently the JSON serialization of the toxic object will add in fields like `Toxicity`, `Direction` or `Name` even if they are 'null' or default values.

This means for example if you don't explicitly set Toxicity, you'll end up with 0.

However, there are defaults in the actual toxiproxy:
https://github.com/Shopify/toxiproxy#toxic-fields

With this change the fields will not be included in the json created if they are `null`.


First test is a little fragile, since it depends on Toxiproxy's behavior
e.g.
`Assert.Equal( "latency_downstream", toxic.Name );`